### PR TITLE
upgrade spring-boot from 2.2.7.RELEASE to 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,4 @@ env:
   - secure: AhiCe6O7DEW9BAWTp4jXF9udcJrpbKKGCVQM/P8E34M6nqBQt+DOkjjoVo+5cigAdBWr8bMdyy8SQBmjAbKIyqbd5pYw8FX4iJ1YEgwa2aqwSbHhrD7xfZAbHTH9M+bjctQE0aceLLq2iiqTrkvDP8fDxPLvle3cYK3ud3exhXICHe+KSjgRekVFNFawEKR3Oht4NUWRqkjpTo9cOcH/VRVmGGg5c7yvGMGK8vfSxuUxn1Ug694IuOTtfjA+8T8ncqJXxe5VUtgf8zT6OkmViAEvQFtbIhCpds2s4pl5XamCFZwzT70mRjmslkVfWFabY4KrV45R/Rc6WQ5kFc1I0TXaJT4BPLmmV9GBu5fAZssCJ3LVdJLLj3A+8b5Y0EJZq0gD9WjfRJP4CcfR0Sjq6ABaXLtH7eytrUv6659wXNj1pk5HcMNL/gLhoz53a2BOW6eHjOzNbUyn11Mr2ysvf2gbsBTPAcUU26jPiSeuiM+lFku5Rlc8ZjZEacpk9koe/zkozOdZeSaQ3B4bnNRoVWAIWukzMyFKq2e8HKxQcH7a6o6+/8mFImOlgCPczSkRy97h4JNwn4qJH49WulMiBBC/rmG2erR8Qipmt9iQJHQcxmXSbOb162x8imoe9Hw5emJAfR4Q48edfVO2BhcLqB+hvpcHhhwI5ZbX0PUB7CU=
 
 before_install:
-- openssl aes-256-cbc -K $encrypted_7b50f5e46b66_key -iv $encrypted_7b50f5e46b66_iv
-  -in travis/sonatype_signing.asc.enc -out travis/sonatype_signing.asc -d
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -K $encrypted_7b50f5e46b66_key -iv $encrypted_7b50f5e46b66_iv -in travis/sonatype_signing.asc.enc -out travis/sonatype_signing.asc -d; fi

--- a/httpclient-spring-boot-autoconfigure/src/test/java/de/dev/eth0/springboot/httpclient/HttpClientAutoConfigurationTest.java
+++ b/httpclient-spring-boot-autoconfigure/src/test/java/de/dev/eth0/springboot/httpclient/HttpClientAutoConfigurationTest.java
@@ -26,7 +26,6 @@ public class HttpClientAutoConfigurationTest {
 
   private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
       .withBean(HttpClientConfiguration.class)
-      .withBean(HttpClientAutoConfiguration.class)
       .withBean(HttpClientBuilder.class)
       .withBean(OkHttpClient.Builder.class);
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>io.wcm.maven</groupId>
     <artifactId>io.wcm.maven.global-parent</artifactId>
-    <version>35</version>
+    <version>36</version>
     <relativePath />
   </parent>
 
@@ -63,8 +63,8 @@
     <!-- versions -->
     <java.version>11</java.version>
 
-    <spring-boot.version>2.2.7.RELEASE</spring-boot.version>
-    <spring-cloud.version>Hoxton.SR8</spring-cloud.version>
+    <spring-boot.version>2.4.2</spring-boot.version>
+    <spring-cloud.version>2020.0.1</spring-cloud.version>
   </properties>
 
   <dependencyManagement>
@@ -94,28 +94,6 @@
         <artifactId>httpclient-spring-boot-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
-
-      <dependency>
-        <groupId>org.hibernate.validator</groupId>
-        <artifactId>hibernate-validator</artifactId>
-        <version>6.1.5.Final</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.11.2</version>
-      </dependency>
-      <dependency>
-        <groupId>io.github.openfeign</groupId>
-        <artifactId>feign-okhttp</artifactId>
-        <version>11.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp-testing-support</artifactId>
-        <version>3.14.9</version>
-        <scope>test</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -141,7 +119,7 @@
         <plugin>
           <groupId>com.amashchenko.maven.plugin</groupId>
           <artifactId>gitflow-maven-plugin</artifactId>
-          <version>1.14.0</version>
+          <version>1.15.1</version>
           <configuration>
             <commitMessagePrefix>[gitflow-maven-plugin] </commitMessagePrefix>
           </configuration>


### PR DESCRIPTION
As dependabot failed, I give it a try:

spring-boot.version 2.4.2
spring-cloud.version 2020.0.1
io.wcm.maven.global-parent 36

Had to take out ".withBean(HttpClientAutoConfiguration.class)" in HttpClientAutoConfigurationTest, otherwise
 There is already [Generic bean: class [de.dev.eth0.springboot.httpclient.HttpClientAutoConfiguration]; scope=singleton; abstract=false; lazyInit=null; autowireMode=0; dependencyCheck=0; autowireCandidate=true; primary=false; factoryBeanName=null; factoryMethodName=null; initMethodName=null; destroyMethodName=null] bound.

Removed unused dependencyManagement entries